### PR TITLE
fix npe when activity is destroyed by os while has fragments

### DIFF
--- a/core/src/main/java/io/github/azaiats/androidmvvm/core/delegates/ViewModelCache.java
+++ b/core/src/main/java/io/github/azaiats/androidmvvm/core/delegates/ViewModelCache.java
@@ -154,7 +154,9 @@ class ViewModelCache {
          * @param key the key
          */
         void remove(int key) {
-            cache.remove(key);
+            if (cache != null) {
+                cache.remove(key);
+            }
         }
 
         @Override


### PR DESCRIPTION
fix npe in ViewModelCache when activity is being destroyed by the os(could be simulated by enabling "don't keep activities") and trying to remove a fragment's vm from cache when cache has already been null-ed by the dedicated ui-less caching fragment's onDestroy callback.
