### PR TITLE
Fix vm ondestroy callback not called

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'com.novoda:bintray-release:0.3.4'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ task clean(type: Delete) {
 ext {
     minSdk = 14
     targetSdk = 24
-    buildToolsVersion = '23.0.3'
+    buildToolsVersion = '24.0.2'
     compileSdkVersion = 24
 
     javaSourceCompatibility = JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
     javaSourceCompatibility = JavaVersion.VERSION_1_7
     javaTargetCompatibility = JavaVersion.VERSION_1_7
 
-    support_version = '23.4.0'
+    support_version = '24.2.0'
     junit_version = '4.12'
     mockito_version = '2.0.52-beta'
     robolectric_version = '3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ task clean(type: Delete) {
 
 ext {
     minSdk = 14
-    targetSdk = 23
+    targetSdk = 24
     buildToolsVersion = '23.0.3'
-    compileSdkVersion = 23
+    compileSdkVersion = 24
 
     javaSourceCompatibility = JavaVersion.VERSION_1_7
     javaTargetCompatibility = JavaVersion.VERSION_1_7

--- a/core/src/main/java/io/github/azaiats/androidmvvm/core/delegates/ActivityDelegate.java
+++ b/core/src/main/java/io/github/azaiats/androidmvvm/core/delegates/ActivityDelegate.java
@@ -78,7 +78,7 @@ public class ActivityDelegate<T extends ViewDataBinding, S extends MvvmViewModel
 
     @Override
     protected boolean isFinished() {
-        return delegatedActivity.isFinishing();
+        return !delegatedActivity.isChangingConfigurations();
     }
 
     @Nullable

--- a/core/src/test/java/io/github/azaiats/androidmvvm/core/delegates/ActivityDelegateTest.java
+++ b/core/src/test/java/io/github/azaiats/androidmvvm/core/delegates/ActivityDelegateTest.java
@@ -100,7 +100,7 @@ public class ActivityDelegateTest {
 
     @Test
     public void testDelegateToActivityFinishingCheck() {
-        when(activity.isFinishing()).thenReturn(true).thenReturn(false);
+        when(activity.isChangingConfigurations()).thenReturn(false).thenReturn(true);
         assertTrue(activityDelegate.isFinished());
         assertFalse(activityDelegate.isFinished());
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/navigation/src/main/java/io/github/azaiats/androidmvvm/navigation/delegates/NavigatingActivityDelegate.java
+++ b/navigation/src/main/java/io/github/azaiats/androidmvvm/navigation/delegates/NavigatingActivityDelegate.java
@@ -65,9 +65,9 @@ public class NavigatingActivityDelegate<T extends Navigator, S extends ViewDataB
 
     @Override
     public void onDestroy() {
-        super.onDestroy();
         if (viewModel != null) {
             viewModel.setNavigator(null);
         }
+        super.onDestroy();
     }
 }

--- a/navigation/src/main/java/io/github/azaiats/androidmvvm/navigation/delegates/NavigatingFragmentDelegate.java
+++ b/navigation/src/main/java/io/github/azaiats/androidmvvm/navigation/delegates/NavigatingFragmentDelegate.java
@@ -65,9 +65,9 @@ public class NavigatingFragmentDelegate<T extends Navigator, S extends ViewDataB
 
     @Override
     public void onDestroy() {
-        super.onDestroy();
         if (viewModel != null) {
             viewModel.setNavigator(null);
         }
+        super.onDestroy();
     }
 }


### PR DESCRIPTION
When activity is destroyed by the os(can be simulated by setting 'don't keep activities'), activity's 'isFinished' will return false and therefore onDestroy callback for the activity's vm will not get called.
Changed the condition in ActivityDelegate's 'isFinished' to consider 'isChangingConfigurations' instead so that it can handle all 3 cases(config change, finished or killed by os).
Had to also make sure that navigator is set to null by 'NavigatingActivityDelegate' before calling super.onDestroy since base class might set vm to null(resulting in navigator not being removed)
